### PR TITLE
fix(css): #CRRE-594 fix campaign display name on admin page

### DIFF
--- a/src/main/resources/public/template/administrator/order/order-waiting.html
+++ b/src/main/resources/public/template/administrator/order/order-waiting.html
@@ -181,7 +181,7 @@
                 </td>
                 <td>
                     <div class="smallTabElem">
-                        <div class="smallTabElem center">[[order.campaign_name]]</div>
+                        <div class="smallTabElem descriptionTruncate center" tooltip="[[order.campaign_name]]">[[order.campaign_name]]</div>
                     </div>
                 </td>
                 <td>


### PR DESCRIPTION
## Describe your changes
When the campaign name was too long, the display moved the column in the table.

## Checklist tests
Have a campaign with a long name.
The name is only displayed on 2 lines and we have the 3 dots at the end of the 2nd line.

## Issue ticket number and link
[CRRE-594](https://jira.support-ent.fr/browse/CRRE-594)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

