### PR TITLE
feat: #CRRE-211 add LDE default value for harvester

### DIFF
--- a/src/main/java/fr/openent/crre/Crre.java
+++ b/src/main/java/fr/openent/crre/Crre.java
@@ -93,7 +93,7 @@ public class Crre extends BaseServer {
         addController(new QuoteController(serviceFactory));
         addController(new WorkflowController(serviceFactory));
         if (serviceFactory.getConfig().isDevMode()) {
-            addController(new DevController());
+            addController(new DevController(serviceFactory));
         }
         vertx.deployVerticle(ExportWorker.class, new DeploymentOptions().setConfig(config).setWorker(true));
         CONFIG = config;

--- a/src/main/java/fr/openent/crre/controllers/DevController.java
+++ b/src/main/java/fr/openent/crre/controllers/DevController.java
@@ -1,6 +1,7 @@
 package fr.openent.crre.controllers;
 
 import fr.openent.crre.core.constants.Field;
+import fr.openent.crre.service.ServiceFactory;
 import fr.wseduc.rs.Get;
 import fr.wseduc.rs.Post;
 import fr.wseduc.webutils.http.Renders;
@@ -16,25 +17,32 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class DevController extends ControllerHelper {
-    static private Map<String, String> txtStatusMap = new HashMap<>();
-    static private Map<String, JsonArray> infoMap = new HashMap<>();
+    static private final Map<String, String> txtStatusMap = new HashMap<>();
+    static private final Map<String, JsonArray> infoMap = new HashMap<>();
+    private static final String LDE_CAT_PAP = "https://www.lde.fr/4dlink1/4DCGI/IDF/json_cat_pap.json";
+    private static final String LDE_CAT_NUM = "https://www.lde.fr/4dlink1/4DCGI/IDF/json_cat_num.json";
+    private final ServiceFactory serviceFactory;
+
+    public DevController(ServiceFactory serviceFactory) {
+        this.serviceFactory = serviceFactory;
+    }
 
     // Protect by dev mode
-    @Get("/dev/bookseller/status/:id")
+    @Get("/dev/bookseller/status/:bookseller")
     // Allows you to retrieve the status of a bookseller
     public void getStatus(final HttpServerRequest request) {
         request.response()
                 .putHeader("Content-Type", "text/csv; charset=utf-8")
                 .putHeader("Content-Disposition", "attachment; filename=libraryStatus.txt")
-                .end(txtStatusMap.getOrDefault(request.params().get(Field.ID), generateExport(new JsonObject())));
+                .end(txtStatusMap.getOrDefault(request.params().get(Field.BOOKSELLER), generateExport(new JsonObject())));
     }
 
     // Protect by dev mode
-    @Post("/dev/bookseller/status/:id")
+    @Post("/dev/bookseller/status/:bookseller")
     // Allows you to define the status of a bookseller
     public void setStatus(final HttpServerRequest request) {
         RequestUtils.bodyToJson(request, body -> {
-            txtStatusMap.put(request.params().get(Field.ID), generateExport(body));
+            txtStatusMap.put(request.params().get(Field.BOOKSELLER), generateExport(body));
             Renders.ok(request);
         });
     }
@@ -56,18 +64,48 @@ public class DevController extends ControllerHelper {
     }
 
     // Protect by dev mode
-    @Get("/dev/bookseller/info/:id")
+    @Get("/dev/bookseller/info/:bookseller")
     // Allows you to retrieve the status of a bookseller
     public void getInfo(final HttpServerRequest request) {
-        Renders.renderJson(request, infoMap.getOrDefault(request.params().get(Field.ID), new JsonArray()));
+        // For dev environments only, when there is no value, the LDE values are taken by default
+        if (Field.PAPIER.equals(request.params().get(Field.BOOKSELLER)) && (!infoMap.containsKey(request.params().get(Field.BOOKSELLER)) || infoMap.get(request.params().get(Field.BOOKSELLER)).isEmpty())) {
+            this.serviceFactory.getWebClient().getAbs(LDE_CAT_PAP)
+                            .send(httpResponseAsyncResult -> {
+                                if (httpResponseAsyncResult.succeeded()) {
+                                    request.response().setStatusCode(200)
+                                            .headers().addAll(httpResponseAsyncResult.result().headers());
+                                    request.response().write(httpResponseAsyncResult.result().bodyAsString());
+                                } else {
+                                    Renders.renderError(request);
+                                }
+                            });
+            return;
+        }
+
+        // For dev environments only, when there is no value, the LDE values are taken by default
+        if (Field.NUMERIC.equals(request.params().get(Field.BOOKSELLER)) && (!infoMap.containsKey(request.params().get(Field.BOOKSELLER)) || infoMap.get(request.params().get(Field.BOOKSELLER)).isEmpty())) {
+            this.serviceFactory.getWebClient().getAbs(LDE_CAT_NUM)
+                    .send(httpResponseAsyncResult -> {
+                        if (httpResponseAsyncResult.succeeded()) {
+                            request.response().setStatusCode(200)
+                                    .headers().addAll(httpResponseAsyncResult.result().headers());
+                            request.response().write(httpResponseAsyncResult.result().bodyAsString());
+                        } else {
+                            Renders.renderError(request);
+                        }
+                    });
+            return;
+        }
+
+        Renders.renderJson(request, infoMap.getOrDefault(request.params().get(Field.BOOKSELLER), new JsonArray()));
     }
 
     // Protect by dev mode
-    @Post("/dev/bookseller/info/:id")
+    @Post("/dev/bookseller/info/:bookseller")
     // Permet de récupérer les information d'un libraire a moissoner
     public void setInfo(final HttpServerRequest request) {
         RequestUtils.bodyToJson(request, body -> {
-            infoMap.put(request.params().get(Field.ID), body.getJsonArray(Field.DATA, new JsonArray()));
+            infoMap.put(request.params().get(Field.BOOKSELLER), body.getJsonArray(Field.DATA, new JsonArray()));
             Renders.ok(request);
         });
     }

--- a/src/main/java/fr/openent/crre/core/constants/Field.java
+++ b/src/main/java/fr/openent/crre/core/constants/Field.java
@@ -271,6 +271,9 @@ public class Field {
     public static final String PARAM = "param";
     public static final String BOOKSELLERS = "booksellers";
     public static final String CONSO = "conso";
+    public static final String BOOKSELLER = "bookseller";
+    public static final String PAPIER = "papier";
+    public static final String NUMERIC = "numeric";
 
     private Field() {
         throw new IllegalStateException("Utility class");


### PR DESCRIPTION
## Describe your changes
Added default LDE catalog for dev environments.
The txtStatusMap and infoMap variables work as a cache. When the spingboard is restarted we lose the defined values which forces us to redefine them for each start.

## Issue ticket number and link
[CRRE-211](https://jira.support-ent.fr/browse/CRRE-211)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

