### PR TITLE
fix: CRRE-602 fix item model not convert to json when search from catalog

### DIFF
--- a/src/main/java/fr/openent/crre/controllers/EquipmentController.java
+++ b/src/main/java/fr/openent/crre/controllers/EquipmentController.java
@@ -168,7 +168,7 @@ public class EquipmentController extends ControllerHelper {
             FilterItemModel filterItemModel = getFilterFromRequest(request);
             if (!filterItemModel.isEmpty()) {
                 equipmentService.searchFilter(filterItemModel, null)
-                        .onSuccess(result -> Renders.renderJson(request, new JsonObject().put(Field.RESOURCES, result)))
+                        .onSuccess(result -> Renders.renderJson(request, new JsonObject().put(Field.RESOURCES, IModelHelper.toJsonArray(result))))
                         .onFailure(error -> {
                             Renders.renderError(request);
                             log.error(String.format("[CRRE@%s::SearchEquipment] Failed to get items filtered and searched %s:%s",


### PR DESCRIPTION
## Describe your changes
When you search as a prescriber from the catalog, the API responds with the field keys in English. This was due to the fact that we have to convert the Item model ourselves before returning it.

## Checklist tests
As a prescriber looking for the ean of an article.

## Issue ticket number and link
[CRRE-602](https://jira.support-ent.fr/browse/CRRE-602)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

