### PR TITLE
feat: #CRRE-469 merge the 2 tabs on the history side (establishment interfaces)

### DIFF
--- a/src/main/java/fr/openent/crre/controllers/OrderController.java
+++ b/src/main/java/fr/openent/crre/controllers/OrderController.java
@@ -73,9 +73,9 @@ public class OrderController extends ControllerHelper {
                 String startDate = request.getParam(Field.STARTDATE);
                 String endDate = request.getParam(Field.ENDDATE);
                 Boolean old = request.getParam(Field.OLD) == null ? null : Boolean.parseBoolean(request.getParam(Field.OLD));
-
-                List<OrderStatus> orderStatusList = Arrays.stream(OrderStatus.values())
-                        .filter(orderStatus -> old == null || orderStatus.isHistoricStatus() == old)
+                List<OrderStatus> statusList = request.params().getAll(Field.STATUS).stream()
+                        .map(OrderStatus::getValue)
+                        .filter(Objects::nonNull)
                         .collect(Collectors.toList());
 
                 FilterModel filterModel = new FilterModel()
@@ -85,7 +85,7 @@ public class OrderController extends ControllerHelper {
                         .setIdsBasket(basketIdList)
                         .setStartDate(startDate)
                         .setEndDate(endDate)
-                        .setStatus(orderStatusList)
+                        .setStatus(statusList)
                         .setOrderByForOrderList(DefaultOrderService.OrderByOrderListEnum.PRESCRIBER_VALIDATION_DATE)
                         .setOrderDescForOrderList(false);
 

--- a/src/main/java/fr/openent/crre/service/BasketOrderService.java
+++ b/src/main/java/fr/openent/crre/service/BasketOrderService.java
@@ -1,9 +1,9 @@
 package fr.openent.crre.service;
 
+import fr.openent.crre.core.enums.OrderStatus;
 import fr.openent.crre.model.BasketOrder;
 import fr.openent.crre.model.TransactionElement;
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
 import org.entcore.common.user.UserInfos;
 
 import java.util.List;
@@ -18,10 +18,10 @@ public interface BasketOrderService {
      * @param idStructure structure identifier
      * @param startDate start date for search
      * @param endDate end date for search
-     * @param oldTable serach in history table or not
+     * @param statusList status filter
      */
     Future<List<BasketOrder>> getMyBasketOrders(String userId, Integer page, Integer idCampaign, String idStructure,
-                                                String startDate, String endDate, boolean oldTable);
+                                                String startDate, String endDate, List<OrderStatus> statusList);
 
     /**
      * Search basket from a query (name, user_name or article)
@@ -32,10 +32,10 @@ public interface BasketOrderService {
      * @param idStructure structure identifier
      * @param startDate starting date filter
      * @param endDate ending date filter
-     * @param old search in historic or not
+     * @param statusList status filter
      */
     Future<List<BasketOrder>> search(String query, UserInfos user, List<String> equipementIdList, int idCampaign, String idStructure,
-                                     String startDate, String endDate, Integer page, Boolean old);
+                                     String startDate, String endDate, Integer page, List<OrderStatus> statusList);
 
     /**
      * Get transaction element for create a new basketOrder

--- a/src/main/resources/public/template/prescriptor/order/manage-order.html
+++ b/src/main/resources/public/template/prescriptor/order/manage-order.html
@@ -36,6 +36,16 @@
                            i18n-placeholder="search.filter.order">
                 </div>
             </div>
+            <div class="cell two margin-top-8 twelve-mobile">
+                <multi-combo title="[[lang.translate('crre.request.state')]]"
+                             combo-model="statusFilterValue"
+                             search-on="orderStatusEnum" order-by="orderStatusEnum"
+                             labels="comboLabels" filtered-model="filter.statusFilterList"
+                             selection-event="searchByName(true)"
+                             deselection-event="searchByName(true)"
+                             class="inline-block horizontal-spacing no-border">
+                </multi-combo>
+            </div>
             <div class="cell twelve-mobile right-magnet">
                 <button class="right-magnet" ng-click="exportCSV()"><i18n>crre.orderEquipment.manage.exportCSV</i18n></button>
             </div>

--- a/src/main/resources/public/template/prescriptor/order/orders-list.html
+++ b/src/main/resources/public/template/prescriptor/order/orders-list.html
@@ -1,10 +1,3 @@
-<div style="margin-bottom: -0.5%; margin-top: 1%">
-    <input type="radio" id="item_1" name="box" checked="">
-    <label for="item_1" ng-click="changeOld(false)" class="labeltabOrder"><i18n>crre.orders.waiting.validation</i18n></label>
-    <input type="radio" id="item_2" name="box">
-    <label for="item_2" ng-click="changeOld(true)" class="labeltabOrder"><i18n>crre.orders.sent.library</i18n>
-    </label>
-</div>
 <div class="flex-row">
     <table class="twelve-mobile twelve">
         <thead>
@@ -66,13 +59,13 @@
             </td>
             <td>
                 <div class="smallTabElem center centerInputAmount">
-                    <i class="moins" ng-if="(order.status !== 'IN_PROGRESS' && order.status !== 'RESUBMIT' && !filter.isOld) && order.valid"
+                    <i class="moins" ng-if="order.status == 'WAITING' && order.valid"
                        ng-hide="!order.amount || order.amount <= 1" ng-click="updateAmount(basket, order, order.amount - 1)"></i>
                     <input type="number" class="quantity-input numberWithoutArrow" step="1" min="1" ng-keypress="avoidDecimals($event)"
-                           ng-disabled="order.status === 'IN_PROGRESS' || order.status === 'RESUBMIT' || filter.isOld || !order.valid"
+                           ng-disabled="order.status != 'WAITING' || !order.valid"
                            ng-change="updateAmount(basket, order, order.amount)"
                            ng-model="order.amount"/>
-                    <i class="plus_medium" ng-if="(order.status !== 'IN_PROGRESS' && order.status !== 'RESUBMIT' && !filter.isOld) && order.valid"
+                    <i class="plus_medium" ng-if="order.status == 'WAITING' && order.valid"
                        ng-click="updateAmount(basket, order, order.amount + 1)"></i>
                 </div>
             </td>

--- a/src/main/resources/public/template/validator/order-historic.html
+++ b/src/main/resources/public/template/validator/order-historic.html
@@ -9,7 +9,7 @@
                     <i class="diary-calendar"></i>
                     <date-picker
                             ng-model="projectFilter.startDate"
-                            ng-change="search(filter.isOld)"
+                            ng-change="search()"
                             class="input-date-picker-style">
                     </date-picker>
                 </div>
@@ -21,7 +21,7 @@
                     <i class="diary-calendar"></i>
                     <date-picker
                             ng-model="projectFilter.endDate"
-                            ng-change="search(filter.isOld)"
+                            ng-change="search()"
                             class="input-date-picker-style">
                     </date-picker>
                 </div>
@@ -32,15 +32,15 @@
                     <input class="twelve"
                            type="text"
                            ng-model="projectFilter.queryName"
-                           ng-keyup="$event.keyCode == 13 ? search(filter.isOld) : null"
+                           ng-keyup="$event.keyCode == 13 ? search() : null"
                            i18n-placeholder="search.filter.order">
                 </div>
             </div>
-            <div class="cell two margin-top-8 twelve-mobile" ng-if="filter.isOld">
-                <multi-combo title="[[lang.translate('Renews')]]"
-                             combo-model="renews"
-                             search-on="name" order-by="name"
-                             labels="comboLabels" filtered-model="projectFilter.renew"
+            <div class="cell two margin-top-8 twelve-mobile">
+                <multi-combo title="[[lang.translate('crre.request.state')]]"
+                             combo-model="statusFilterValue"
+                             search-on="orderStatusEnum" order-by="orderStatusEnum"
+                             labels="comboLabels" filtered-model="projectFilter.statusFilterList"
                              selection-event="getFilter()"
                              deselection-event="getFilter()"
                              class="inline-block horizontal-spacing no-border">
@@ -49,13 +49,6 @@
             <div class="cell twelve-mobile right-magnet">
                 <button ng-click="display.projects.exportCSV(false)" class="right-magnet"><i18n>crre.logs.csv.export</i18n></button>
             </div>
-        </div>
-        <div style="margin-bottom: -0.5%; margin-top: 1%">
-            <input type="radio" id="item_1" name="box" checked="">
-            <label for="item_1" ng-click="changeOld(false)" class="labeltabOrder"><i18n>crre.orders.waiting.validation</i18n></label>
-            <input type="radio" id="item_2" name="box">
-            <label for="item_2" ng-click="changeOld(true)" class="labeltabOrder"><i18n>crre.orders.sent.library</i18n>
-            </label>
         </div>
         <div class="flex-row">
             <table class="twelve-mobile twelve">
@@ -212,7 +205,7 @@
             </div>
 -->
         </div>
-        <infinite-scroll-v2 scrolled="onScroll(filter.isOld)" loading-mode="false"></infinite-scroll-v2>
+        <infinite-scroll-v2 scrolled="onScroll()" loading-mode="false"></infinite-scroll-v2>
         <section class="toggle-buttons" ng-class="{ hide: !display.toggle }">
             <div class="toggle">
                 <div class="row">

--- a/src/main/resources/public/ts/controllers/administrator/order/waitingOrder.ts
+++ b/src/main/resources/public/ts/controllers/administrator/order/waitingOrder.ts
@@ -18,6 +18,7 @@ import {Mix} from "entcore-toolkit";
 import {StatusFilter} from "../../../model/StatusFilter";
 import {ORDER_BY_PROJECT_FIELD_ENUM} from "../../../enum/order-by-project-field-enum";
 import {TypeCatalogEnum} from "../../../enum/type-catalog-enum";
+import {idiom as lang} from 'entcore';
 
 export const waitingOrderRegionController = ng.controller('waitingOrderRegionController',
     ['$scope', async ($scope) => {
@@ -54,7 +55,9 @@ export const waitingOrderRegionController = ng.controller('waitingOrderRegionCon
         const init = async () => {
             $scope.projectFilter.orderBy = ORDER_BY_PROJECT_FIELD_ENUM.DATE;
             $scope.projectFilter.orderDesc = true;
-            $scope.statusFilterList = [new StatusFilter(ORDER_STATUS_ENUM.ARCHIVED), new StatusFilter(ORDER_STATUS_ENUM.SENT), new StatusFilter(ORDER_STATUS_ENUM.IN_PROGRESS),
+            let newFilter: StatusFilter = new StatusFilter(ORDER_STATUS_ENUM.IN_PROGRESS);
+            newFilter.toString = (): string => lang.translate("NEW");
+            $scope.statusFilterList = [new StatusFilter(ORDER_STATUS_ENUM.ARCHIVED), new StatusFilter(ORDER_STATUS_ENUM.SENT), newFilter,
                 new StatusFilter(ORDER_STATUS_ENUM.VALID), new StatusFilter(ORDER_STATUS_ENUM.DONE), new StatusFilter(ORDER_STATUS_ENUM.REJECTED)];
 
             $scope.schoolType = [{name: 'PU'}, {name: 'PR'}];

--- a/src/main/resources/public/ts/controllers/prescriptor/order/order-list.ts
+++ b/src/main/resources/public/ts/controllers/prescriptor/order/order-list.ts
@@ -8,14 +8,6 @@ import {
 export const orderController = ng.controller('orderController',
     ['$scope', async ($scope) => {
 
-        $scope.changeOld = async (old: boolean) => {
-            if ($scope.filter.isOld !== old) {
-                $scope.filter.isOld = old;
-                $scope.startInitLoading();
-                await $scope.getOrders();
-            }
-        };
-
         $scope.switchAllOrders = (allOrdersListSelected: boolean) => {
             $scope.displayedBasketsOrders.map((basket) => {
                 basket.selected = allOrdersListSelected;

--- a/src/main/resources/public/ts/controllers/validator/order-historic.ts
+++ b/src/main/resources/public/ts/controllers/validator/order-historic.ts
@@ -1,49 +1,25 @@
 import {ng, toasts} from 'entcore';
 import {
-    Utils,
     Basket,
-    Equipment,
-    FilterFront,
-    Filter,
     Baskets,
     Campaign,
+    Equipment,
+    OrderClient,
+    OrderRegion,
     OrdersClient,
     Project,
-    OrderRegion,
-    OrderClient,
+    Utils,
 } from "../../model";
 import {Mix} from "entcore-toolkit";
 import {AxiosResponse} from "axios";
 import {ORDER_STATUS_ENUM} from "../../enum/order-status-enum";
+import {StatusFilter} from "../../model/StatusFilter";
 
 export const historicOrderRegionController = ng.controller('historicOrderRegionController',
     ['$scope', async ($scope) => {
-        $scope.filter = {
-            isOld: false
-        };
-        $scope.filterChoice = {
-            renew: []
-        };
-        $scope.filterChoiceCorrelation = {
-            keys: ["renew"],
-            renew: 'renew'
-        };
-        $scope.renews = [{name: 'true'}, {name: 'false'}];
-        $scope.renews.forEach((item : {name : string}) => item.toString = () => $scope.translate(item.name));
-
-
-        $scope.changeOld = async (old: boolean) : Promise<void> => {
-            if ($scope.filter.isOld !== old) {
-                $scope.filter.isOld = old;
-                $scope.projectFilter.page = 0;
-                $scope.filtersFront.all = [];
-                $scope.filters.all = []
-                $scope.display.loading = true;
-                $scope.display.projects.all = [];
-                Utils.safeApply($scope);
-                await $scope.synchroRegionOrders(null,false, null, $scope.filter.isOld);
-            }
-        };
+        $scope.statusFilterValue = [new StatusFilter(ORDER_STATUS_ENUM.VALID), new StatusFilter(ORDER_STATUS_ENUM.IN_PROGRESS),
+            new StatusFilter(ORDER_STATUS_ENUM.REJECTED), new StatusFilter(ORDER_STATUS_ENUM.SENT),
+            new StatusFilter(ORDER_STATUS_ENUM.DONE), new StatusFilter(ORDER_STATUS_ENUM.ARCHIVED)];
 
         $scope.canResubmit = () : boolean => {
             return $scope.display.projects.all.flatMap((project : Project) => project.orders)
@@ -98,23 +74,7 @@ export const historicOrderRegionController = ng.controller('historicOrderRegionC
         };
 
         $scope.getFilter = async () : Promise<void> => {
-            $scope.filters.all = [];
-            $scope.filtersFront.all = [];
-            for (const key of Object.keys($scope.filterChoice)) {
-                let newFilterFront : FilterFront = new FilterFront();
-                newFilterFront.name = $scope.filterChoiceCorrelation[key];
-                newFilterFront.value = [];
-                $scope.filterChoice[key].forEach(item => {
-                    let newFilter : Filter = new Filter();
-                    newFilter.name = $scope.filterChoiceCorrelation[key];
-                    let value = item.name;
-                    newFilter.value = value;
-                    newFilterFront.value.push(value);
-                    $scope.filters.all.push(newFilter);
-                });
-                $scope.filtersFront.all.push(newFilterFront);
-            }
-            await $scope.searchProjectAndOrders($scope.filter.isOld, false, false);
+            await $scope.searchProjectAndOrders(null, false, false);
         };
 
         const uncheckAll = () : void => {

--- a/src/main/resources/public/ts/controllers/validator/order-to-region.ts
+++ b/src/main/resources/public/ts/controllers/validator/order-to-region.ts
@@ -24,7 +24,6 @@ import {TypeCatalogEnum} from "../../enum/type-catalog-enum";
 export const orderRegionController = ng.controller('orderRegionController',
     ['$scope', async ($scope) => {
         $scope.filters = new Filters();
-        $scope.filtersFront = new FiltersFront();
         $scope.structures = new Structures();
         $scope.filtersDate = [];
         $scope.filtersDate.startDate = moment().add(-6, 'months')._d;
@@ -63,12 +62,6 @@ export const orderRegionController = ng.controller('orderRegionController',
             Utils.safeApply($scope);
             let projects = new Projects();
             $scope.projectFilter.structureList.push($scope.current.structure as Structure);
-            if (old) {
-                $scope.projectFilter.statusFilterList = Utils.getHistoricalStatus().map((value: ORDER_STATUS_ENUM) => new StatusFilter(value)) as Array<StatusFilter>;
-            } else {
-                $scope.projectFilter.statusFilterList = [new StatusFilter(ORDER_STATUS_ENUM.VALID), new StatusFilter(ORDER_STATUS_ENUM.IN_PROGRESS),
-                    new StatusFilter(ORDER_STATUS_ENUM.REJECTED), new StatusFilter(ORDER_STATUS_ENUM.RESUBMIT)] as Array<StatusFilter>;
-            }
             if($scope.display.projects.all.length > 0) {
                 $scope.projectFilter.page++;
             }
@@ -85,17 +78,11 @@ export const orderRegionController = ng.controller('orderRegionController',
                 });
          };
 
-        $scope.searchProjectAndOrders = async (old = false, all: boolean, onlyId: boolean) => {
+        $scope.searchProjectAndOrders = async (old: boolean, all: boolean, onlyId: boolean) => {
             let projects = new Projects();
             initProjects();
             all ? $scope.projectFilter.page = null : 0;
             $scope.projectFilter.structureList.push($scope.current.structure as Structure);
-            if (old) {
-                $scope.projectFilter.statusFilterList = Utils.getHistoricalStatus().map((value: ORDER_STATUS_ENUM) => new StatusFilter(value)) as Array<StatusFilter>;
-            } else {
-                $scope.projectFilter.statusFilterList = [new StatusFilter(ORDER_STATUS_ENUM.VALID), new StatusFilter(ORDER_STATUS_ENUM.IN_PROGRESS),
-                    new StatusFilter(ORDER_STATUS_ENUM.REJECTED), new StatusFilter(ORDER_STATUS_ENUM.RESUBMIT)] as Array<StatusFilter>;
-            }
             projects.search($scope.projectFilter)
                 .then(async (data: Project[]) => {
                     if (data && data.length > 0) {
@@ -109,12 +96,6 @@ export const orderRegionController = ng.controller('orderRegionController',
 
         $scope.search = async (old = false) => {
             $scope.projectFilter.page = 0;
-            if (old) {
-                $scope.projectFilter.statusFilterList = Utils.getHistoricalStatus().map((value: ORDER_STATUS_ENUM) => new StatusFilter(value)) as Array<StatusFilter>;
-            } else {
-                $scope.projectFilter.statusFilterList = [new StatusFilter(ORDER_STATUS_ENUM.VALID), new StatusFilter(ORDER_STATUS_ENUM.IN_PROGRESS),
-                    new StatusFilter(ORDER_STATUS_ENUM.REJECTED), new StatusFilter(ORDER_STATUS_ENUM.RESUBMIT)] as Array<StatusFilter>;
-            }
             if ($scope.filters.all.length == 0 && !$scope.projectFilter.queryName) {
                 initProjects();
                 await $scope.synchroRegionOrders(false, false, null, old);
@@ -165,12 +146,6 @@ export const orderRegionController = ng.controller('orderRegionController',
             let projects = new Projects();
             if (!isSearching) {
                 $scope.projectFilter.structureList.push($scope.current.structure as Structure);
-                if (old) {
-                    $scope.projectFilter.statusFilterList = Utils.getHistoricalStatus().map((value: ORDER_STATUS_ENUM) => new StatusFilter(value)) as Array<StatusFilter>;
-                } else {
-                    $scope.projectFilter.statusFilterList = [new StatusFilter(ORDER_STATUS_ENUM.VALID), new StatusFilter(ORDER_STATUS_ENUM.IN_PROGRESS),
-                        new StatusFilter(ORDER_STATUS_ENUM.REJECTED), new StatusFilter(ORDER_STATUS_ENUM.RESUBMIT)] as Array<StatusFilter>;
-                }
                 await projects.search($scope.projectFilter);
             } else {
                 projects = (projectsResult) ? projectsResult : $scope.display.projects;
@@ -264,8 +239,8 @@ export const orderRegionController = ng.controller('orderRegionController',
             }
         }
 
-        $scope.synchroRegionOrders = async (isSearching: boolean = false, onlyId: boolean = false, projectsList?: Projects,
-                                            old = false): Promise<void> => {
+        $scope.synchroRegionOrders = async (isSearching: boolean = false, onlyId: boolean = false, projectsList: Projects,
+                                            old: boolean): Promise<void> => {
             let {projects, responses} = await getOrdersOfProjects(isSearching, old, projectsList);
             if (responses[0]) {
                 let projectsResult = [];

--- a/src/main/resources/public/ts/model/Basket.ts
+++ b/src/main/resources/public/ts/model/Basket.ts
@@ -3,6 +3,7 @@ import {moment, toasts} from 'entcore';
 import http from 'axios';
 import {Equipment, Offers, OrdersClient, Structure, Utils} from './index';
 import {TypeCatalogEnum} from "../enum/type-catalog-enum";
+import {ORDER_STATUS_ENUM} from "../enum/order-status-enum";
 
 
 export class Basket implements Selectable {
@@ -195,16 +196,17 @@ export class BasketsOrders extends Selection<BasketOrder> {
         super([]);
     }
 
-    async search(text: String, id_campaign: number, start: string, end: string, page?: number, old?: boolean, idStructure?: string) {
+    async search(text: String, id_campaign: number, start: string, end: string, statusFilter: Array<ORDER_STATUS_ENUM>, page?: number, idStructure?: string) {
         try {
             if ((text.trim() === '' || !text)) return;
             const {startDate, endDate} = Utils.formatDate(start, end);
             const pageParams = (page) ? `&page=${page}` : ``;
-            let url = `/crre/basketOrder/search?startDate=${startDate}&endDate=${endDate}&old=${old}&q=${text}`;
+            let url: string = `/crre/basketOrder/search?startDate=${startDate}&endDate=${endDate}&q=${text}`;
             if (idStructure) {
                 url += `&idStructure=${idStructure}`;
             }
             url += `&idCampaign=${id_campaign}${pageParams}`;
+            statusFilter.forEach((status: ORDER_STATUS_ENUM) => url += `&status=${status}`);
             const {data} = await http.get(url);
             return this.setBaskets(data);
         } catch (err) {
@@ -213,12 +215,13 @@ export class BasketsOrders extends Selection<BasketOrder> {
         }
     }
 
-    async getMyOrders(page: number, start: string, end: string, id_campaign: string, old: boolean, structureId: string) {
+    async getMyOrders(page: number, start: string, end: string, id_campaign: string, statusFilter: Array<ORDER_STATUS_ENUM>, structureId: string) {
         try {
             const {startDate, endDate} = Utils.formatDate(start, end);
             const pageParams = (page) ? `&page=${page}` : ``;
-            let url = `/crre/basketOrder/allMyOrders?idCampaign=${id_campaign}&old=${old}&idStructure=${structureId}`;
+            let url: string = `/crre/basketOrder/allMyOrders?idCampaign=${id_campaign}&idStructure=${structureId}`;
             url += `&startDate=${startDate}&endDate=${endDate}${pageParams}`;
+            statusFilter.forEach((status: ORDER_STATUS_ENUM) => url += `&status=${status}`);
             let {data} = await http.get(url);
             return this.setBaskets(data);
         } catch (e) {

--- a/src/main/resources/public/ts/model/OrderClient.ts
+++ b/src/main/resources/public/ts/model/OrderClient.ts
@@ -21,6 +21,7 @@ import {OrderUniversal} from "./OrderUniversal";
 import {OrderSearchAmount} from "./OrderSearchAmount";
 import {ExportOrderFilter} from "./ExportOrderFilter";
 import {TypeCatalogEnum} from "../enum/type-catalog-enum";
+import {ORDER_STATUS_ENUM} from "../enum/order-status-enum";
 
 declare let window: any;
 
@@ -138,7 +139,7 @@ export class OrdersClient extends Selection<OrderClient> {
     }
 
     async syncMyOrder(filter: ValidatorOrderWaitingFilter, idCampaign: number,
-                      idStructure: string, ordersId: Array<number>, old = false): Promise<boolean> {
+                      idStructure: string, ordersId: Array<number>): Promise<boolean> {
         let dateParam = "";
         if (filter.startDate && filter.endDate) {
             const {startDate, endDate} = Utils.formatDate(filter.startDate, filter.endDate);
@@ -148,7 +149,8 @@ export class OrdersClient extends Selection<OrderClient> {
         ordersId.map((order) => {
             params += `basket_id=${order}&`;
         });
-        let url: string = `/crre/orders/mine/${idCampaign}/${idStructure}${params}${dateParam}old=${old}`;
+        filter.status.forEach((status: ORDER_STATUS_ENUM) => params += `status=${status}&`);
+        let url: string = `/crre/orders/mine/${idCampaign}/${idStructure}${params}${dateParam}`;
         const {data} = await http.get(url);
         let newOrderClient: Array<OrderClient> = Mix.castArrayAs(OrderUniversal, data)
             .map((order: OrderUniversal) => {

--- a/src/main/resources/public/ts/model/StatusFilter.ts
+++ b/src/main/resources/public/ts/model/StatusFilter.ts
@@ -22,10 +22,6 @@ export class StatusFilter implements IFilter{
     }
 
     toString() {
-        if (this._orderStatusEnum === ORDER_STATUS_ENUM.IN_PROGRESS) {
-            return lang.translate("NEW");
-        } else {
-            return lang.translate(this._orderStatusEnum)
-        }
+        return lang.translate(this._orderStatusEnum);
     }
 }

--- a/src/main/resources/public/ts/model/ValidatorOrderWaitingFilter.ts
+++ b/src/main/resources/public/ts/model/ValidatorOrderWaitingFilter.ts
@@ -1,6 +1,7 @@
 import {moment} from "entcore";
 import {UserModel} from "./UserModel";
 import {Campaign} from "./Campaign";
+import {ORDER_STATUS_ENUM} from "../enum/order-status-enum";
 
 export class ValidatorOrderWaitingFilter {
     startDate;
@@ -9,6 +10,7 @@ export class ValidatorOrderWaitingFilter {
     userList: Array<UserModel>;
     typeCampaignList: Array<Campaign>;
     filterChoiceCorrelation: Map<string, string>;
+    private _status: Array<ORDER_STATUS_ENUM>;
 
 
     constructor() {
@@ -18,9 +20,19 @@ export class ValidatorOrderWaitingFilter {
         this.userList = [];
         this.typeCampaignList = [];
         this.filterChoiceCorrelation = new Map<string, string>();
+        this._status = [];
     }
 
     filterChoiceCorrelationKey(): Array<string> {
         return Array.from(this.filterChoiceCorrelation.keys());
+    }
+
+
+    get status(): Array<ORDER_STATUS_ENUM> {
+        return this._status;
+    }
+
+    set status(value: Array<ORDER_STATUS_ENUM>) {
+        this._status = value;
     }
 }


### PR DESCRIPTION
## Describe your changes
As a validator and prescriber, we no longer want to have 2 tabs in the history. At the beach we want a page with a filter to filter by status.

API doc: https://confluence.support-ent.fr/display/CRRE/API+1.7.0

## Checklist tests
In both histories, the tab is no longer available. The status filter works both with and without the text search filter.

## Issue ticket number and link
[CRRE-469](https://jira.support-ent.fr/browse/CRRE-469)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

