### PR TITLE
fix: #CRRE-647 fix missing filter when returning to the catalog

### DIFF
--- a/src/main/resources/public/template/administrator/management-main.html
+++ b/src/main/resources/public/template/administrator/management-main.html
@@ -23,7 +23,7 @@
         </drop-down-menu>
     </header>
     <header class="horizontal-spacing" ng-class="{ selected : selectedType.startsWith('/equipments/catalog') }"
-            ng-click="redirectTo('/equipments/catalog')">
+            ng-click="switchToCatalogTab()">
         <i18n>crre.catalog</i18n>
     </header>
     <header class="horizontal-spacing" ng-class="{selected: (selectedType == '/campaigns' || selectedType == '/structureGroups')}">

--- a/src/main/resources/public/ts/controllers/main.ts
+++ b/src/main/resources/public/ts/controllers/main.ts
@@ -621,4 +621,9 @@ export const mainController = ng.controller('MainController', ['$scope', 'route'
             Utils.safeApply($scope);
         }
 
+        $scope.switchToCatalogTab = () => {
+            $scope.equipments = new Equipments();
+            $scope.redirectTo('/equipments/catalog');
+        }
+
     }]);

--- a/src/main/resources/public/ts/controllers/prescriptor/catalog/catalog.ts
+++ b/src/main/resources/public/ts/controllers/prescriptor/catalog/catalog.ts
@@ -8,7 +8,6 @@ export const catalogController = ng.controller('catalogController',
             $scope.pageSize = 20;
             $scope.nbItemsDisplay = $scope.pageSize;
             $scope.equipment = new Equipment();
-            $scope.equipments = new Equipments();
             $scope.equipments.loading = true;
             $scope.loading = true;
 


### PR DESCRIPTION
## Describe your changes
When you are on the catalog, when you select a filter, then you display the detail of an article and when you return, the filter disappears.

## Checklist tests
As an administrator, quickly switch to the catalog tab as soon as you arrive on CRRE. Filters will still be present.

As administrator and prescriber, go to the catalog, select a filter. View an item's details, then select "Return". The filters will still be present, the selection is kept and the other options are still selectable.

## Issue ticket number and link
[CRRE-647](https://jira.support-ent.fr/browse/CRRE-647)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

