### PR TITLE
fix: #CRRE-648 fix of the type of resources filter on the prescriber page

### DIFF
--- a/src/main/resources/public/ts/controllers/prescriptor/catalog/catalog.ts
+++ b/src/main/resources/public/ts/controllers/prescriptor/catalog/catalog.ts
@@ -64,7 +64,10 @@ export const catalogController = ng.controller('catalogController',
                 } else if ($scope.campaign.catalog.split("|").includes("ressource")) {
                     consommableFilter.value = "Ressource";
                 }
-                $scope.filters.all.push(consommableFilter);
+
+                if (consommableFilter.value) {
+                    $scope.filters.all.push(consommableFilter);
+                }
 
                 // If catalog contain pro/lgt filter
                 if ($scope.campaign.catalog.split("|").includes("pro") || $scope.campaign.catalog.split("|").includes("lgt")) {
@@ -125,10 +128,12 @@ export const catalogController = ng.controller('catalogController',
                 }
             }
             await $scope.equipments.getFilterEquipments($scope.query.word, $scope.filters);
-            $scope.equipments.filters.consumables = [{name: 'Consommable'}, {name: 'Manuel'}, {name: 'Ressource'}] as FilterCatalogItem[];
-            $scope.equipments.filters.consumables.forEach((item) => item.toString = () => $scope.translate(item.name));
-            $scope.equipments.filters.pros = [{name: 'Lycée général et technologique'}, {name: 'Lycée professionnel'}] as FilterCatalogItem[];
-            $scope.equipments.filters.pros.forEach((item) => item.toString = () => $scope.translate(item.name));
+            $scope.equipments.filters.consumables = [new FilterCatalogItem('Consommable'), new FilterCatalogItem('Manuel'), new FilterCatalogItem('Ressource')];
+            $scope.equipments.filters.consumables.forEach((item: FilterCatalogItem) => item.toString = () => $scope.translate(item.name));
+            $scope.catalog.consumables = $scope.equipments.filters.consumables.filter((item: FilterCatalogItem) => $scope.catalog.consumables.find((itemCatalog: FilterCatalogItem) => item.name == itemCatalog.name));
+            $scope.equipments.filters.pros = [new FilterCatalogItem('Lycée général et technologique'), new FilterCatalogItem('Lycée professionnel')];
+            $scope.equipments.filters.pros.forEach((item: FilterCatalogItem) => item.toString = () => $scope.translate(item.name));
+            $scope.catalog.pros = $scope.equipments.filters.pros.filter((item: FilterCatalogItem) => $scope.catalog.pros.find((itemCatalog: FilterCatalogItem) => item.name == itemCatalog.name));
 
             Utils.safeApply($scope);
             if (!!$scope.campaign.catalog) {


### PR DESCRIPTION
## Describe your changes
When you are on a catalog as a prescriber, if you select filters, you consult an article, then return. Back on the catalog, the filter has disappeared but the selection is kept.

## Checklist tests
As a prescriber, when consulting a catalog, if you select the "Type of resources" filter, consult an article, then go back, the filter remains applied and visible.
In addition, when viewing a digital campaign as a prescriber and filtering by resource, only the resources are displayed.

## Issue ticket number and link
[CRRE-648](https://jira.support-ent.fr/browse/CRRE-648)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

