### PR TITLE
fix: #CRRE-650 fix bookseller statuses do not appear in prescriber interface

### DIFF
--- a/src/main/java/fr/openent/crre/core/constants/Field.java
+++ b/src/main/java/fr/openent/crre/core/constants/Field.java
@@ -290,6 +290,8 @@ public class Field {
     public static final String CONSUMABLE_INITIAL_AMOUNT = "consumable_initial_amount";
     public static final String ADDED_INITIAL_AMOUNT = "added_initial_amount";
     public static final String ADDED_CONSUMABLE_INITIAL_AMOUNT = "added_consumable_initial_amount";
+    public static final String ID_STATUS = "id_status";
+    public static final String STATUS_NAME = "status_name";
 
 
     private Field() {

--- a/src/main/java/fr/openent/crre/model/OrderUniversalModel.java
+++ b/src/main/java/fr/openent/crre/model/OrderUniversalModel.java
@@ -45,6 +45,8 @@ public class OrderUniversalModel implements IModel<OrderUniversalModel> {
     private Double equipmentTva20;
     private Double equipmentPriceht;
     private String equipmentBookseller;
+    private Integer idStatus;
+    private String statusName;
     private StudentsTableModel students;
 
     private List<OrderUniversalOfferModel> offers;
@@ -92,6 +94,8 @@ public class OrderUniversalModel implements IModel<OrderUniversalModel> {
         this.equipmentTva20 = jsonObject.getDouble(Field.EQUIPMENT_TVA20);
         this.equipmentPriceht = jsonObject.getDouble(Field.EQUIPMENT_PRICEHT);
         this.equipmentBookseller = jsonObject.getString(ItemField.BOOKSELLER);
+        this.idStatus = jsonObject.getInteger(Field.ID_STATUS);
+        this.statusName = jsonObject.getString(Field.STATUS_NAME);
 
         this.totalFree = jsonObject.getInteger(Field.TOTAL_FREE);
         if (jsonObject.getValue(Field.PROJECT) != null && jsonObject.getValue(Field.PROJECT) instanceof JsonObject) {
@@ -508,6 +512,24 @@ public class OrderUniversalModel implements IModel<OrderUniversalModel> {
 
     public OrderUniversalModel setValid(boolean valid) {
         this.valid = valid;
+        return this;
+    }
+
+    public Integer getIdStatus() {
+        return idStatus;
+    }
+
+    public OrderUniversalModel setIdStatus(Integer idStatus) {
+        this.idStatus = idStatus;
+        return this;
+    }
+
+    public String getStatusName() {
+        return statusName;
+    }
+
+    public OrderUniversalModel setStatusName(String statusName) {
+        this.statusName = statusName;
         return this;
     }
 }

--- a/src/main/java/fr/openent/crre/service/impl/DefaultOrderService.java
+++ b/src/main/java/fr/openent/crre/service/impl/DefaultOrderService.java
@@ -54,7 +54,7 @@ public class DefaultOrderService extends SqlCrudService implements OrderService 
     public Future<List<OrderUniversalModel>> listOrder(FilterModel filterModel) {
         Promise<List<OrderUniversalModel>> promise = Promise.promise();
         JsonArray values = new JsonArray();
-        String query = "SELECT " + getOrderUniversalSelector() + ", to_jsonb(basket.*) basket, to_jsonb(campaign.*) campaign, to_jsonb(project.*) project," +
+        String query = "SELECT o_u.*, to_jsonb(basket.*) basket, to_jsonb(campaign.*) campaign, to_jsonb(project.*) project," +
                 " to_jsonb(students.*) students" +
                 " FROM crre.order_universal as o_u" +
                 " LEFT JOIN crre.basket_order basket on o_u.id_basket = basket.id" +
@@ -115,17 +115,6 @@ public class DefaultOrderService extends SqlCrudService implements OrderService 
         sql.prepared(query, values, SqlResult.validResultHandler(IModelHelper.sqlResultToIModel(promise, OrderUniversalModel.class, errorMessage)));
 
         return promise.future();
-    }
-
-    private String getOrderUniversalSelector() {
-        return "o_u.amount as amount, o_u.prescriber_validation_date as prescriber_validation_date, o_u.id_campaign as id_campaign, o_u.id_structure as id_structure," +
-                " o_u.status as status, o_u.equipment_key as equipment_key, o_u.cause_status as cause_status, o_u.comment as comment," +
-                " o_u.prescriber_id as prescriber_id, o_u.id_basket as id_basket, o_u.reassort as reassort, o_u.validator_id as validator_id," +
-                " o_u.validator_name as validator_name, o_u.validator_validation_date as validator_validation_date, o_u.modification_date as modification_date," +
-                " o_u.id_project as id_project," +
-                " o_u.equipment_name, o_u.equipment_image, o_u.equipment_price, o_u.equipment_grade," +
-                " o_u.equipment_editor, o_u.equipment_diffusor, o_u.equipment_format, o_u.equipment_tva5, o_u.equipment_tva20," +
-                " o_u.equipment_priceht, o_u.offers, o_u.total_free, o_u.order_client_id, o_u.order_region_id";
     }
 
     @Override

--- a/src/main/resources/public/ts/model/OrderClient.ts
+++ b/src/main/resources/public/ts/model/OrderClient.ts
@@ -64,7 +64,9 @@ export class OrderClient implements Order {
     type: string;
     displayStatus: boolean;
     projectTitle: string;
-    valid: boolean
+    valid: boolean;
+    status_name: string;
+    status_id: number;
 
     constructor() {
         this.typeOrder = "client";
@@ -181,6 +183,8 @@ export class OrdersClient extends Selection<OrderClient> {
                 orderMap.status = order.status;
                 orderMap.projectTitle = (!order.project) ? null : order.project.title;
                 orderMap.valid = order.valid;
+                orderMap.status_id = order.id_status;
+                orderMap.status_name = order.status_name;
                 return orderMap;
             });
 

--- a/src/main/resources/public/ts/model/OrderUniversal.ts
+++ b/src/main/resources/public/ts/model/OrderUniversal.ts
@@ -30,6 +30,8 @@ export class OrderUniversal {
     private _equipment_tva5: number;
     private _equipment_tva20: number;
     private _equipment_priceht: number;
+    private _id_status: number;
+    private _status_name: string;
     private _offers: any[];
     private _totalFree: number;
     private _valid: boolean;
@@ -293,5 +295,21 @@ export class OrderUniversal {
 
     set valid(value: boolean) {
         this._valid = value;
+    }
+
+    get id_status() {
+        return this._id_status;
+    }
+
+    set id_status(value) {
+        this._id_status = value;
+    }
+
+    get status_name() {
+        return this._status_name;
+    }
+
+    set status_name(value) {
+        this._status_name = value;
     }
 }

--- a/src/main/resources/sql/022-add-id-status-to-order-view.sql
+++ b/src/main/resources/sql/022-add-id-status-to-order-view.sql
@@ -1,0 +1,80 @@
+DROP VIEW crre.order_universal;
+CREATE OR REPLACE VIEW crre.order_universal as
+(
+SELECT oce.amount            as amount,
+       oce.creation_date     as prescriber_validation_date,
+       oce.id_campaign       as id_campaign,
+       oce.id_structure      as id_structure,
+       oce.status            as status,
+       oce.equipment_key     as equipment_key,
+       oce.cause_status      as cause_status,
+       oce.comment           as comment,
+       oce.user_id           as prescriber_id,
+       oce.id_basket         as id_basket,
+       oce.reassort          as reassort,
+       ore.owner_id          as validator_id,
+       ore.owner_name        as validator_name,
+       ore.creation_date     as validator_validation_date,
+       ore.modification_date as modification_date,
+       ore.id_project        as id_project,
+
+       NULL                  as equipment_name,
+       NULL                  as equipment_image,
+       NULL                  as equipment_price,
+       NULL                  as equipment_grade,
+       NULL                  as equipment_editor,
+       NULL                  as equipment_diffusor,
+       NULL                  as equipment_format,
+       NULL                  as equipment_tva5,
+       NULL                  as equipment_tva20,
+       NULL                  as equipment_priceht,
+       NULL                  as offers,
+       NULL                  as total_free,
+       NULL                  as id_status,
+       NULL                  as status_name,
+
+       oce.id                as order_client_id,
+       ore.id                as order_region_id
+
+FROM crre.order_client_equipment as oce
+         LEFT JOIN crre."order-region-equipment" as ore on oce.id = ore.id_order_client_equipment
+         LEFT JOIN crre."order-region-equipment" as "o-r-e" on oce.id = "o-r-e".id_order_client_equipment
+UNION ALL
+SELECT oceo.amount            as amount,
+       oceo.creation_date     as prescriber_validation_date,
+       oceo.id_campaign       as id_campaign,
+       oceo.id_structure      as id_structure,
+       oceo.status            as status,
+       oceo.equipment_key     as equipment_key,
+       oceo.cause_status      as cause_status,
+       oceo.comment           as comment,
+       oceo.user_id           as prescriber_id,
+       oceo.id_basket         as id_basket,
+       oceo.reassort          as reassort,
+       oreo.owner_id          as validator_id,
+       oreo.owner_name        as validator_name,
+       oreo.creation_date     as validator_validation_date,
+       oreo.modification_date as modification_date,
+       oreo.id_project        as id_project,
+
+       oceo.equipment_name,
+       oceo.equipment_image,
+       oceo.equipment_price,
+       oceo.equipment_grade,
+       oceo.equipment_editor,
+       oceo.equipment_diffusor,
+       oceo.equipment_format,
+       oceo.equipment_tva5,
+       oceo.equipment_tva20,
+       oceo.equipment_priceht,
+       oceo.offers,
+       oreo.total_free,
+       oreo.id_status,
+       status_table.name as status_name,
+
+       oceo.id                as order_client_id,
+       oreo.id                as order_region_id
+FROM crre.order_client_equipment_old as oceo
+         LEFT JOIN crre."order-region-equipment-old" as oreo on oceo.id = oreo.id_order_client_equipment
+         LEFT JOIN crre.status as status_table on oreo.id_status = status_table.id
+    );

--- a/src/test/java/fr/openent/crre/service/impl/DefaultOrderServiceTest.java
+++ b/src/test/java/fr/openent/crre/service/impl/DefaultOrderServiceTest.java
@@ -126,14 +126,7 @@ public class DefaultOrderServiceTest {
     public void listOrderTest(TestContext ctx) {
         Async async = ctx.async();
 
-        String expectedQuery = "SELECT o_u.amount as amount, o_u.prescriber_validation_date as prescriber_validation_date," +
-                " o_u.id_campaign as id_campaign, o_u.id_structure as id_structure, o_u.status as status, o_u.equipment_key" +
-                " as equipment_key, o_u.cause_status as cause_status, o_u.comment as comment, o_u.prescriber_id as prescriber_id," +
-                " o_u.id_basket as id_basket, o_u.reassort as reassort, o_u.validator_id as validator_id, o_u.validator_name" +
-                " as validator_name, o_u.validator_validation_date as validator_validation_date, o_u.modification_date as" +
-                " modification_date, o_u.id_project as id_project, o_u.equipment_name, o_u.equipment_image, o_u.equipment_price," +
-                " o_u.equipment_grade, o_u.equipment_editor, o_u.equipment_diffusor, o_u.equipment_format, o_u.equipment_tva5," +
-                " o_u.equipment_tva20, o_u.equipment_priceht, o_u.offers, o_u.total_free, o_u.order_client_id, o_u.order_region_id," +
+        String expectedQuery = "SELECT o_u.*," +
                 " to_jsonb(basket.*) basket, to_jsonb(campaign.*) campaign, to_jsonb(project.*) project, to_jsonb(students.*)" +
                 " students FROM crre.order_universal as o_u LEFT JOIN crre.basket_order basket on o_u.id_basket = basket.id" +
                 " LEFT JOIN crre.project project on o_u.id_project = project.id LEFT JOIN crre.campaign campaign on campaign" +


### PR DESCRIPTION
## Describe your changes
When the prescriber is in his order history, he no longer sees the status of the orders

Doc d'api: https://confluence.support-ent.fr/display/CRRE/API+1.7.0
## Checklist tests
As a prescriber, when you have an order sent to the bookseller with a specific status, in the history of the prescriber, you can see the name of this status.

## Issue ticket number and link
[CRRE-650](https://jira.support-ent.fr/browse/CRRE-650)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

