### PR TITLE
fix: #CRRE-649 fix false vat in csv export from the admin interface

### DIFF
--- a/src/main/java/fr/openent/crre/controllers/OrderController.java
+++ b/src/main/java/fr/openent/crre/controllers/OrderController.java
@@ -331,8 +331,8 @@ public class OrderController extends ControllerHelper {
     public static String exportPriceComment(OrderUniversalModel orderUniversalModel) {
         return (orderUniversalModel.getAmount() != null ? orderUniversalModel.getAmount() : "") + ";" +
                 (orderUniversalModel.getEquipmentPriceht() != null ? Double.parseDouble(OrderUtils.df2.format(orderUniversalModel.getEquipmentPriceht())) : "") + ";" +
-                (orderUniversalModel.getEquipmentPriceTva5() != null ? orderUniversalModel.getEquipmentTva5() : "") + ";" +
-                (orderUniversalModel.getEquipmentPriceTva20() != null ? orderUniversalModel.getEquipmentTva20() : "") + ";" +
+                (orderUniversalModel.getEquipmentTva5() != null ? orderUniversalModel.getEquipmentTva5() : "") + ";" +
+                (orderUniversalModel.getEquipmentTva20() != null ? orderUniversalModel.getEquipmentTva20() : "") + ";" +
                 (orderUniversalModel.getUnitedPriceTTC() != null ? convertPriceString(orderUniversalModel.getUnitedPriceTTC()) : "") + ";" +
                 (orderUniversalModel.getTotalPriceHT() != null ? convertPriceString(orderUniversalModel.getTotalPriceHT()) : "") + ";" +
                 (orderUniversalModel.getTotalPriceTTC() != null ? convertPriceString(orderUniversalModel.getTotalPriceTTC()) : "") + ";" +

--- a/src/main/java/fr/openent/crre/model/OrderUniversalModel.java
+++ b/src/main/java/fr/openent/crre/model/OrderUniversalModel.java
@@ -441,11 +441,11 @@ public class OrderUniversalModel implements IModel<OrderUniversalModel> {
     }
 
     public Double getEquipmentPriceTva5() {
-        return this.getEquipmentTva5() != null ? getRoundedPrice(this.amount + this.equipmentTva5) : null;
+        return this.getEquipmentTva5() != null ? getRoundedPrice(this.amount * this.equipmentTva5) : null;
     }
 
     public Double getEquipmentPriceTva20() {
-        return this.getEquipmentTva20() != null ? getRoundedPrice(this.amount + this.equipmentTva20) : null;
+        return this.getEquipmentTva20() != null ? getRoundedPrice(this.amount * this.equipmentTva20) : null;
     }
 
     public String getEquipmentCatalogueType() {

--- a/src/main/java/fr/openent/crre/service/impl/DefaultOrderRegionService.java
+++ b/src/main/java/fr/openent/crre/service/impl/DefaultOrderRegionService.java
@@ -622,8 +622,8 @@ public class DefaultOrderRegionService extends SqlCrudService implements OrderRe
             params.add(order.getBasket().getId())
                     .add(order.getReassort())
                     .add(offers)
-                    .add(order.getEquipmentPriceTva5())
-                    .add(order.getEquipmentPriceTva20())
+                    .add(order.getEquipmentTva5())
+                    .add(order.getEquipmentTva20())
                     .add(order.getEquipmentPriceht());
         }
         query = new StringBuilder(query.substring(0, query.length() - 1));

--- a/src/test/java/fr/openent/crre/service/impl/DefaultOrderRegionServiceTest.java
+++ b/src/test/java/fr/openent/crre/service/impl/DefaultOrderRegionServiceTest.java
@@ -444,9 +444,9 @@ public class DefaultOrderRegionServiceTest {
                 "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         String expectedParams = "[183,13,\"validationDate\",\"prescriberId\",\"SENT\",\"equipmentKey\",\"equipmentName\"," +
                 "\"equipmentImage\",843.1,\"grade\",\"editor\",\"diffusor\",\"catalogueType\",156,\"idStructure\",\"comment\"," +
-                "95,false,[],211.25,29.65,510.2,42,52,\"validationDate2\",\"prescriberId2\",\"ARCHIVED\",\"equipmentKey2\"," +
+                "95,false,[],198.25,16.65,510.2,42,52,\"validationDate2\",\"prescriberId2\",\"ARCHIVED\",\"equipmentKey2\"," +
                 "\"equipmentName2\",\"equipmentImage2\",245.5,\"grade2\",\"editor2\",\"diffusor2\",\"catalogueType2\",72," +
-                "\"idStructure2\",\"comment2\",42,false,[],76.5,475.4,32.1]";
+                "\"idStructure2\",\"comment2\",42,false,[],24.5,423.4,32.1]";
 
         TransactionElement transactionElement = Whitebox.invokeMethod(this.defaultOrderRegionService, "insertOldClientOrderList", orderList);
         ctx.assertEquals(expectedQuery, transactionElement.getQuery());


### PR DESCRIPTION
## Describe your changes
When the region administrator export orders send to the bookseller the VAT calculation is wrong.

## Checklist tests
Make a new order and send it to the bookseller. As administrator, export the order. The VAT price is correctly calculated.

## Issue ticket number and link
[CRRE-649](https://jira.support-ent.fr/browse/CRRE-649)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

