### PR TITLE
fix: #CRRE-658 calculation of budgets when there is more than one page

### DIFF
--- a/src/main/java/fr/openent/crre/service/impl/DefaultOrderService.java
+++ b/src/main/java/fr/openent/crre/service/impl/DefaultOrderService.java
@@ -133,7 +133,7 @@ public class DefaultOrderService extends SqlCrudService implements OrderService 
         query = filterWaitingOrder(status, idStructure, query, startDate, endDate, values);
 
         query += "GROUP BY (bo.name, bo.name_user, oce.id, campaign.id, ore.status) " +
-                "ORDER BY oce.creation_date DESC ";
+                "ORDER BY oce.creation_date DESC, oce.id DESC ";
         if (page != null) {
             query += "OFFSET ? LIMIT ? ";
             values.add(PAGE_SIZE * page);

--- a/src/main/resources/public/ts/controllers/validator/orders-waiting.ts
+++ b/src/main/resources/public/ts/controllers/validator/orders-waiting.ts
@@ -49,12 +49,13 @@ export const waitingValidatorOrderController = ng.controller('waitingValidatorOr
 
         $scope.loadNextPage = async (): Promise<void> => {
             $scope.filter.page++;
-            const newData = await $scope.ordersClient.searchOrder($scope.current.structure.id, $scope.filterOrder, false, $scope.filter.page);
-            endLoading(newData);
-            $scope.loading = false;
-
-            $scope.syncSelected();
-            Utils.safeApply($scope);
+            if (!$scope.loading) {
+                const newData = await $scope.ordersClient.searchOrder($scope.current.structure.id, $scope.filterOrder, false, $scope.filter.page);
+                endLoading(newData);
+                $scope.loading = false;
+                $scope.syncSelected();
+                Utils.safeApply($scope);
+            }
         };
 
         $scope.getAllFilters = async () => {
@@ -104,7 +105,7 @@ export const waitingValidatorOrderController = ng.controller('waitingValidatorOr
             let ordersClient: OrdersClient;
             if ($scope.allOrdersSelected) {
                 $scope.allOrderCLient.all.forEach(order => {
-                    for (let i = 0; i <= $scope.ordersClient.all.length; i++) {
+                    for (let i = 0; i < $scope.ordersClient.all.length; i++) {
                         if (order.id == $scope.ordersClient.all[i].id) {
                             order.amount = $scope.ordersClient.all[i].amount;
                             break


### PR DESCRIPTION
## Describe your changes
Lorsque l'on a de nombreux résultats dans une requête sql avec les même valeur dans le order, la pagination sql ne fonctionne pas correctement. (renvois les même donnée entre les différente page)

Lorsque l'on scroll trop rapidement, la meme page pouvais etre chargé.

## Checklist tests
As a validator, go to the requests page where you have several orders pages. Scroll quickly up and down. In the Network tab, filter on the /crre/orders API.

Select 2 commands, then select all commands. The total price is well calculated.
## Issue ticket number and link
[CRRE-658](https://jira.support-ent.fr/browse/CRRE-658)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

