### PR TITLE
fix: #CRRE-660 add display of current filters on prescriber history

### DIFF
--- a/src/main/resources/public/template/prescriptor/order/manage-order.html
+++ b/src/main/resources/public/template/prescriptor/order/manage-order.html
@@ -46,6 +46,16 @@
                              class="inline-block horizontal-spacing no-border">
                 </multi-combo>
             </div>
+            <div class="cell six twelve-mobile" ng-if="filter.statusFilterList.length > 0">
+                <div class="remove-margin-bottom">
+                    <div class="select-blocks inline-block">
+                        <div ng-repeat="item in filter.statusFilterList"
+                             ng-click="dropElement(item)">
+                            [[item.toString()]]
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div class="cell twelve-mobile right-magnet">
                 <button class="right-magnet" ng-click="exportCSV()"><i18n>crre.orderEquipment.manage.exportCSV</i18n></button>
             </div>

--- a/src/main/resources/public/ts/controllers/prescriptor/order/manage-order.ts
+++ b/src/main/resources/public/ts/controllers/prescriptor/order/manage-order.ts
@@ -225,6 +225,11 @@ export const manageOrderController = ng.controller('manageOrderController',
             Utils.safeApply($scope);
         };
 
+        $scope.dropElement = (item: StatusFilter): void => {
+            $scope.filter.statusFilterList = $scope.filter.statusFilterList.filter((el: StatusFilter) => el != item);
+            $scope.searchByName(true);
+        }
+
         await init();
     }])
 ;


### PR DESCRIPTION
## Describe your changes
Missing the display of active filters on the validator history page.

## Checklist tests
As a prescriber, go to the request history page. Add multiple status filters. The page is well filtered. Remove a filter using the cross. The page is again filtered correctly.

## Issue ticket number and link
[CRRE-660](https://jira.support-ent.fr/browse/CRRE-660)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

