### PR TITLE
fix: #CRRE-660 add display of current filters on validator history

### DIFF
--- a/src/main/resources/public/template/validator/order-historic.html
+++ b/src/main/resources/public/template/validator/order-historic.html
@@ -46,6 +46,16 @@
                              class="inline-block horizontal-spacing no-border">
                 </multi-combo>
             </div>
+            <div class="cell six twelve-mobile" ng-if="projectFilter.statusFilterList.length > 0">
+                <div class="remove-margin-bottom">
+                    <div class="select-blocks inline-block">
+                        <div ng-repeat="item in projectFilter.statusFilterList"
+                             ng-click="dropElement(item)">
+                            [[item.toString()]]
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div class="cell twelve-mobile right-magnet">
                 <button ng-click="display.projects.exportCSV(false)" class="right-magnet"><i18n>crre.logs.csv.export</i18n></button>
             </div>

--- a/src/main/resources/public/ts/controllers/validator/order-historic.ts
+++ b/src/main/resources/public/ts/controllers/validator/order-historic.ts
@@ -77,6 +77,11 @@ export const historicOrderRegionController = ng.controller('historicOrderRegionC
             await $scope.searchProjectAndOrders(null, false, false);
         };
 
+        $scope.dropElement = (item: StatusFilter): void => {
+            $scope.projectFilter.statusFilterList = $scope.projectFilter.statusFilterList.filter((el: StatusFilter) => el != item);
+            $scope.getFilter();
+        }
+
         const uncheckAll = () : void => {
             $scope.display.projects.forEach((project : Project) => {
                 project.selected = false;


### PR DESCRIPTION
## Describe your changes
Missing the display of active filters on the validator history page.

## Checklist tests
As a validator, go to the request history page. Add multiple status filters. The page is well filtered. Remove a filter using the cross. The page is again filtered correctly.

## Issue ticket number and link
[CRRE-660](https://jira.support-ent.fr/browse/CRRE-660)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

